### PR TITLE
ci: bump actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     name: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm


### PR DESCRIPTION
## Summary

Node.js 20 deprecation warning を解消するため、CI/Release ワークフローで使う actions を最新メジャーに更新。

- `actions/checkout@v4` → `@v6`
- `actions/setup-node@v4` → `@v6`
- `pnpm/action-setup@v4` → `@v5`

## Test plan

- [ ] CI グリーン（Node 20 deprecation annotation が消えること）