### PR TITLE
chore: declare sideEffects: false for tree-shaking

### DIFF
--- a/.changeset/side-effects-false.md
+++ b/.changeset/side-effects-false.md
@@ -1,0 +1,7 @@
+---
+'@love-rox/tcy-core': patch
+'@love-rox/tcy-react': patch
+'@love-rox/tcy-vue': patch
+---
+
+Declare `sideEffects: false` so bundlers can tree-shake unused exports.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "src"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -25,6 +25,7 @@
     "src"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -25,6 +25,7 @@
     "src"
   ],
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

- `packages/*/package.json` に `"sideEffects": false` を宣言し、バンドラが未使用 export を tree-shake できるようにする
- 3 パッケージとも patch バンプ（0.1.0 → 0.1.1）となる changeset を添付

OIDC Trusted Publishing の初回自動リリースの動作確認も兼ねています。

## Test plan

- [x] `pnpm lint`
- [x] `pnpm format:check`
- [x] `pnpm build`
- [x] `pnpm test`
- [ ] CI グリーン