### PR TITLE
fix(ci): bump Node to 24 for npm 11 + OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 


### PR DESCRIPTION
## Summary

OIDC Trusted Publishing を使うには npm 11.5.1 以上が必要。Node 22 に同梱される npm は 10.9.x で未対応のため publish が 404 で失敗していた。Node 24 は npm 11 を同梱しているので upgrade。

## Test plan

- [ ] CI グリーン
- [ ] マージ後に 0.1.1 の Release PR が再走し、OIDC で npm に publish 成功