### PR TITLE
docs: add per-package README

### DIFF
--- a/.changeset/per-package-readme.md
+++ b/.changeset/per-package-readme.md
@@ -1,0 +1,7 @@
+---
+'@love-rox/tcy-core': patch
+'@love-rox/tcy-react': patch
+'@love-rox/tcy-vue': patch
+---
+
+Add per-package README so the npm package pages show usage docs instead of the "No README" fallback.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,59 @@
+# @love-rox/tcy-core
+
+Framework-agnostic tokenizer for Japanese **tate-chu-yoko (縦中横)** span wrapping.
+
+Returns a `Segment[]` that splits a string into text chunks and target chunks (typically half-width alphanumerics). Framework wrappers build on top of this:
+
+- [`@love-rox/tcy-react`](https://www.npmjs.com/package/@love-rox/tcy-react) — React `<Tcy>` component
+- [`@love-rox/tcy-vue`](https://www.npmjs.com/package/@love-rox/tcy-vue) — Vue 3 `<Tcy>` component
+
+## Install
+
+```bash
+pnpm add @love-rox/tcy-core
+```
+
+## Usage
+
+```ts
+import { tokenize } from '@love-rox/tcy-core';
+
+tokenize('第1章 2026年4月');
+// [
+//   { type: 'text', value: '第' },
+//   { type: 'tcy',  value: '1' },
+//   { type: 'text', value: '章 ' },
+//   { type: 'tcy',  value: '2026' },
+//   { type: 'text', value: '年' },
+//   { type: 'tcy',  value: '4' },
+//   { type: 'text', value: '月' },
+// ]
+```
+
+## API
+
+```ts
+type Segment = { type: 'text'; value: string } | { type: 'tcy'; value: string };
+
+function tokenize(input: string, options?: TcyOptions): Segment[];
+
+interface TcyOptions {
+  target?: 'alphanumeric' | 'alpha' | 'digit' | 'ascii' | RegExp; // default: 'alphanumeric'
+  combine?: boolean; // default: true
+  include?: string | string[];
+  exclude?: string | string[];
+}
+```
+
+- `target`: preset or custom `RegExp` for the characters to wrap. `alphanumeric` = `[0-9A-Za-z]`; `ascii` = full printable ASCII
+- `combine`: if `true`, consecutive target characters become one `tcy` segment; if `false`, each character becomes its own segment
+- `include` / `exclude`: per-character overrides. `exclude` wins over `include`
+
+## Links
+
+- Full documentation: [Love-Rox/tate-chu-yoko](https://github.com/Love-Rox/tate-chu-yoko#readme) ([日本語](https://github.com/Love-Rox/tate-chu-yoko/blob/main/README.ja.md))
+- Issues: https://github.com/Love-Rox/tate-chu-yoko/issues
+
+## License
+
+MIT

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,0 +1,66 @@
+# @love-rox/tcy-react
+
+React `<Tcy>` component for Japanese **tate-chu-yoko (縦中横)** auto-wrap.
+
+Wrap a subtree and half-width alphanumerics inside it are automatically wrapped in `<span>` tags so that CSS `text-combine-upright: all` composes them uprightly within vertical text.
+
+Built on top of [`@love-rox/tcy-core`](https://www.npmjs.com/package/@love-rox/tcy-core).
+
+## Install
+
+```bash
+pnpm add @love-rox/tcy-react
+```
+
+Peer dependency: `react >= 17`.
+
+## CSS
+
+```css
+.tcy {
+  -webkit-text-combine: horizontal;
+  text-combine-upright: all;
+}
+```
+
+## Usage
+
+```tsx
+import { Tcy } from '@love-rox/tcy-react';
+
+export function Chapter() {
+  return (
+    <p style={{ writingMode: 'vertical-rl' }}>
+      <Tcy>第1章 2026年4月、Webの縦書きは進化した。</Tcy>
+    </p>
+  );
+}
+```
+
+Rendered DOM:
+
+```text
+第<span class="tcy">1</span>章 <span class="tcy">2026</span>年<span class="tcy">4</span>月、Webの縦書きは進化した。
+```
+
+## Props
+
+| Prop        | Type                                                        | Default          | Description                                                                                  |
+| ----------- | ----------------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------- |
+| `target`    | `'alphanumeric' \| 'alpha' \| 'digit' \| 'ascii' \| RegExp` | `'alphanumeric'` | What to wrap                                                                                 |
+| `combine`   | `boolean`                                                   | `true`           | Merge consecutive target characters into one span. `false` wraps each character individually |
+| `include`   | `string \| string[]`                                        | `undefined`      | Extra characters to treat as targets                                                         |
+| `exclude`   | `string \| string[]`                                        | `undefined`      | Characters to exclude. Takes precedence over `include`                                       |
+| `className` | `string`                                                    | `'tcy'`          | Class applied to each generated span                                                         |
+| `as`        | `keyof JSX.IntrinsicElements`                               | `'span'`         | Tag name used for wrapping                                                                   |
+
+Nested elements are traversed transparently. Runs are not joined across element boundaries.
+
+## Links
+
+- Full documentation: [Love-Rox/tate-chu-yoko](https://github.com/Love-Rox/tate-chu-yoko#readme) ([日本語](https://github.com/Love-Rox/tate-chu-yoko/blob/main/README.ja.md))
+- Issues: https://github.com/Love-Rox/tate-chu-yoko/issues
+
+## License
+
+MIT

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,0 +1,66 @@
+# @love-rox/tcy-vue
+
+Vue 3 `<Tcy>` component for Japanese **tate-chu-yoko (縦中横)** auto-wrap.
+
+Wrap a subtree and half-width alphanumerics inside it are automatically wrapped in `<span>` tags so that CSS `text-combine-upright: all` composes them uprightly within vertical text.
+
+Built on top of [`@love-rox/tcy-core`](https://www.npmjs.com/package/@love-rox/tcy-core).
+
+## Install
+
+```bash
+pnpm add @love-rox/tcy-vue
+```
+
+Peer dependency: `vue ^3.3.0`.
+
+## CSS
+
+```css
+.tcy {
+  -webkit-text-combine: horizontal;
+  text-combine-upright: all;
+}
+```
+
+## Usage
+
+```vue
+<script setup lang="ts">
+import { Tcy } from '@love-rox/tcy-vue';
+</script>
+
+<template>
+  <p style="writing-mode: vertical-rl">
+    <Tcy class-name="tcy">第1章 2026年4月、Webの縦書きは進化した。</Tcy>
+  </p>
+</template>
+```
+
+Rendered DOM:
+
+```text
+第<span class="tcy">1</span>章 <span class="tcy">2026</span>年<span class="tcy">4</span>月、Webの縦書きは進化した。
+```
+
+## Props
+
+| Prop        | Type                                                        | Default          | Description                                                                                  |
+| ----------- | ----------------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------- |
+| `target`    | `'alphanumeric' \| 'alpha' \| 'digit' \| 'ascii' \| RegExp` | `'alphanumeric'` | What to wrap                                                                                 |
+| `combine`   | `boolean`                                                   | `true`           | Merge consecutive target characters into one span. `false` wraps each character individually |
+| `include`   | `string \| string[]`                                        | `undefined`      | Extra characters to treat as targets                                                         |
+| `exclude`   | `string \| string[]`                                        | `undefined`      | Characters to exclude. Takes precedence over `include`                                       |
+| `className` | `string`                                                    | `'tcy'`          | Class applied to each generated span                                                         |
+| `as`        | `string`                                                    | `'span'`         | Tag name used for wrapping                                                                   |
+
+Nested elements are traversed transparently. Runs are not joined across element boundaries.
+
+## Links
+
+- Full documentation: [Love-Rox/tate-chu-yoko](https://github.com/Love-Rox/tate-chu-yoko#readme) ([日本語](https://github.com/Love-Rox/tate-chu-yoko/blob/main/README.ja.md))
+- Issues: https://github.com/Love-Rox/tate-chu-yoko/issues
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- 各パッケージのルートに簡潔な README を追加（npm のパッケージページで使い方が見えるように）
- core / react / vue 向けに API・Props・Install・Links を個別に記載
- changeset 同梱（3 パッケージすべて patch → 0.1.2）

## Test plan

- [ ] CI グリーン
- [ ] マージ後、0.1.2 として自動 publish される
- [ ] npm のパッケージページで README が表示される