### PR TITLE
feat: add maxLength and excludeWords options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
 
       - run: pnpm format:check
 
-      - run: pnpm check:tsdoc
-
       - run: pnpm build
+
+      - run: pnpm check:tsdoc
 
       - run: pnpm typecheck
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
 
       - run: pnpm format:check
 
+      - run: pnpm check:tsdoc
+
       - run: pnpm build
 
       - run: pnpm typecheck

--- a/README.ja.md
+++ b/README.ja.md
@@ -99,6 +99,8 @@ React / Vue の `<Tcy>` および `tokenize()` 共通:
 | `combine`  | `boolean`                                                   | `true`           | 連続する対象文字を 1 つの span にまとめる。`false` で 1 文字ずつ個別ラップ            |
 | `include`  | `string \| string[]`                                        | `undefined`      | `target` に追加で含める文字。例: `'.'`                                                |
 | `exclude`  | `string \| string[]`                                        | `undefined`      | `target` から除外する文字。`include` より優先                                         |
+| `maxLength`    | `number`                                                    | `undefined`      | tcy セグメントの最大文字数。超過分はラップせずプレーンテキストとして扱う               |
+| `excludeWords` | `string[]`                                                  | `undefined`      | `target` に合致しても除外する単語のリスト（完全一致）                                  |
 
 React / Vue コンポーネント固有:
 
@@ -121,6 +123,14 @@ React / Vue コンポーネント固有:
 // 1 文字ずつ個別 span（個別に回転を当てたい場合など）
 <Tcy combine={false}>ABC</Tcy>
 // → <span class="tcy">A</span><span class="tcy">B</span><span class="tcy">C</span>
+
+// 2 文字以下のみラップ
+<Tcy maxLength={2}>第1章 2026年4月</Tcy>
+// → 第<span class="tcy">1</span>章 2026年<span class="tcy">4</span>月
+
+// 特定の単語を除外
+<Tcy excludeWords={['2026']}>第1章 2026年4月</Tcy>
+// → 第<span class="tcy">1</span>章 2026年<span class="tcy">4</span>月
 
 // ネストした要素も透過
 <Tcy>

--- a/README.ja.md
+++ b/README.ja.md
@@ -93,14 +93,14 @@ tokenize('第1章 2026年4月');
 
 React / Vue の `<Tcy>` および `tokenize()` 共通:
 
-| オプション | 型                                                          | 既定値           | 内容                                                                                  |
-| ---------- | ----------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------- |
-| `target`   | `'alphanumeric' \| 'alpha' \| 'digit' \| 'ascii' \| RegExp` | `'alphanumeric'` | span で囲む対象。`alphanumeric` は `[0-9A-Za-z]`、`ascii` は記号込みの ASCII 可視文字 |
-| `combine`  | `boolean`                                                   | `true`           | 連続する対象文字を 1 つの span にまとめる。`false` で 1 文字ずつ個別ラップ            |
-| `include`  | `string \| string[]`                                        | `undefined`      | `target` に追加で含める文字。例: `'.'`                                                |
-| `exclude`  | `string \| string[]`                                        | `undefined`      | `target` から除外する文字。`include` より優先                                         |
-| `maxLength`    | `number`                                                    | `undefined`      | tcy セグメントの最大文字数。超過分はラップせずプレーンテキストとして扱う               |
-| `excludeWords` | `string[]`                                                  | `undefined`      | `target` に合致しても除外する単語のリスト（完全一致）                                  |
+| オプション     | 型                                                          | 既定値           | 内容                                                                                  |
+| -------------- | ----------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------- |
+| `target`       | `'alphanumeric' \| 'alpha' \| 'digit' \| 'ascii' \| RegExp` | `'alphanumeric'` | span で囲む対象。`alphanumeric` は `[0-9A-Za-z]`、`ascii` は記号込みの ASCII 可視文字 |
+| `combine`      | `boolean`                                                   | `true`           | 連続する対象文字を 1 つの span にまとめる。`false` で 1 文字ずつ個別ラップ            |
+| `include`      | `string \| string[]`                                        | `undefined`      | `target` に追加で含める文字。例: `'.'`                                                |
+| `exclude`      | `string \| string[]`                                        | `undefined`      | `target` から除外する文字。`include` より優先                                         |
+| `maxLength`    | `number`                                                    | `undefined`      | tcy セグメントの最大文字数。超過分はラップせずプレーンテキストとして扱う              |
+| `excludeWords` | `string[]`                                                  | `undefined`      | `target` に合致しても除外する単語のリスト（完全一致）                                 |
 
 React / Vue コンポーネント固有:
 

--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ tokenize('第1章 2026年4月');
 
 Shared by the React / Vue `<Tcy>` components and `tokenize()`:
 
-| Option    | Type                                                        | Default          | Description                                                                                                  |
-| --------- | ----------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------ |
-| `target`  | `'alphanumeric' \| 'alpha' \| 'digit' \| 'ascii' \| RegExp` | `'alphanumeric'` | What to wrap. `alphanumeric` matches `[0-9A-Za-z]`; `ascii` matches the full printable ASCII including marks |
-| `combine` | `boolean`                                                   | `true`           | Merge consecutive target characters into one span. Set `false` to wrap each character individually           |
-| `include` | `string \| string[]`                                        | `undefined`      | Extra characters to treat as targets regardless of `target`                                                  |
-| `exclude` | `string \| string[]`                                        | `undefined`      | Characters to exclude. Takes precedence over `include`                                                       |
+| Option         | Type                                                        | Default          | Description                                                                                                  |
+| -------------- | ----------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------ |
+| `target`       | `'alphanumeric' \| 'alpha' \| 'digit' \| 'ascii' \| RegExp` | `'alphanumeric'` | What to wrap. `alphanumeric` matches `[0-9A-Za-z]`; `ascii` matches the full printable ASCII including marks |
+| `combine`      | `boolean`                                                   | `true`           | Merge consecutive target characters into one span. Set `false` to wrap each character individually           |
+| `include`      | `string \| string[]`                                        | `undefined`      | Extra characters to treat as targets regardless of `target`                                                  |
+| `exclude`      | `string \| string[]`                                        | `undefined`      | Characters to exclude. Takes precedence over `include`                                                       |
 | `maxLength`    | `number`                                                    | `undefined`      | Maximum length for a tcy segment. Segments longer than this are left as plain text                           |
 | `excludeWords` | `string[]`                                                  | `undefined`      | Exact words to exclude from tcy wrapping even when they match `target`                                       |
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Shared by the React / Vue `<Tcy>` components and `tokenize()`:
 | `combine` | `boolean`                                                   | `true`           | Merge consecutive target characters into one span. Set `false` to wrap each character individually           |
 | `include` | `string \| string[]`                                        | `undefined`      | Extra characters to treat as targets regardless of `target`                                                  |
 | `exclude` | `string \| string[]`                                        | `undefined`      | Characters to exclude. Takes precedence over `include`                                                       |
+| `maxLength`    | `number`                                                    | `undefined`      | Maximum length for a tcy segment. Segments longer than this are left as plain text                           |
+| `excludeWords` | `string[]`                                                  | `undefined`      | Exact words to exclude from tcy wrapping even when they match `target`                                       |
 
 Component-only props (React / Vue):
 
@@ -121,6 +123,14 @@ Component-only props (React / Vue):
 // Wrap one character at a time (useful for per-glyph rotation)
 <Tcy combine={false}>ABC</Tcy>
 // → <span class="tcy">A</span><span class="tcy">B</span><span class="tcy">C</span>
+
+// Limit wrapping to segments of 2 characters or fewer
+<Tcy maxLength={2}>第1章 2026年4月</Tcy>
+// → 第<span class="tcy">1</span>章 2026年<span class="tcy">4</span>月
+
+// Exclude specific words from wrapping
+<Tcy excludeWords={['2026']}>第1章 2026年4月</Tcy>
+// → 第<span class="tcy">1</span>章 2026年<span class="tcy">4</span>月
 
 // Nested elements are traversed transparently
 <Tcy>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "pnpm -r --filter \"./packages/*\" run build",
     "test": "pnpm -r --filter \"./packages/*\" run test",
     "typecheck": "pnpm -r --filter \"./packages/*\" run typecheck",
+    "check:tsdoc": "typedoc",
     "lint": "oxlint .",
     "lint:fix": "oxlint . --fix",
     "format": "oxfmt .",
@@ -19,6 +20,7 @@
     "@changesets/cli": "^2.31.0",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",
+    "typedoc": "^0.28.19",
     "typescript": "^5.6.3",
     "vitest": "^2.1.5"
   },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -42,12 +42,16 @@ interface TcyOptions {
   combine?: boolean; // default: true
   include?: string | string[];
   exclude?: string | string[];
+  maxLength?: number;
+  excludeWords?: string[];
 }
 ```
 
 - `target`: preset or custom `RegExp` for the characters to wrap. `alphanumeric` = `[0-9A-Za-z]`; `ascii` = full printable ASCII
 - `combine`: if `true`, consecutive target characters become one `tcy` segment; if `false`, each character becomes its own segment
 - `include` / `exclude`: per-character overrides. `exclude` wins over `include`
+- `maxLength`: maximum length for a tcy segment. Segments longer than this are demoted to plain text
+- `excludeWords`: exact words to exclude from tcy wrapping. Matched against the combined segment value
 
 ## Links
 

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -1,10 +1,50 @@
+/** Preset name for built-in character-class patterns. */
 export type TargetPreset = 'alphanumeric' | 'alpha' | 'digit' | 'ascii';
 
+/** Options shared by {@link tokenize} and the React / Vue `<Tcy>` components. */
 export interface TcyOptions {
+  /**
+   * Which characters to treat as tcy targets.
+   * A preset name selects a built-in pattern; a `RegExp` is tested per character.
+   * @defaultValue `'alphanumeric'`
+   */
   target?: TargetPreset | RegExp;
+  /**
+   * When `true`, consecutive target characters are merged into a single tcy segment.
+   * Set to `false` to wrap each character individually.
+   * @defaultValue `true`
+   */
   combine?: boolean;
+  /**
+   * Extra characters to treat as targets regardless of {@link target}.
+   * Each character in the string (or each string in the array) is added individually.
+   */
   include?: string | string[];
+  /**
+   * Characters to exclude from targeting. Takes precedence over {@link include}.
+   * Each character in the string (or each string in the array) is removed individually.
+   */
   exclude?: string | string[];
+  /**
+   * Maximum length for a tcy segment.
+   * Segments whose length exceeds this value are demoted to plain text.
+   * @example
+   * ```ts
+   * tokenize('第1章 2026年4月', { maxLength: 2 })
+   * // "2026" (4 chars) becomes text; "1" and "4" remain tcy
+   * ```
+   */
+  maxLength?: number;
+  /**
+   * Exact words to exclude from tcy wrapping.
+   * Matched against the combined segment value (exact match, not substring).
+   * @example
+   * ```ts
+   * tokenize('第1章 2026年4月', { excludeWords: ['2026'] })
+   * // "2026" becomes text; "1" and "4" remain tcy
+   * ```
+   */
+  excludeWords?: string[];
 }
 
 const PRESET_PATTERNS: Record<TargetPreset, RegExp> = {
@@ -20,6 +60,12 @@ function toCharSet(input: string | string[] | undefined): Set<string> {
   return new Set(Array.from(joined));
 }
 
+/**
+ * Build a per-character predicate from the given options.
+ * The returned function returns `true` when a character should be treated as a tcy target.
+ *
+ * Priority: {@link TcyOptions.exclude} \> {@link TcyOptions.include} \> {@link TcyOptions.target}.
+ */
 export function buildMatcher(options: TcyOptions = {}): (ch: string) => boolean {
   const { target = 'alphanumeric', include, exclude } = options;
   const pattern = target instanceof RegExp ? target : PRESET_PATTERNS[target];

--- a/packages/core/src/tokenize.ts
+++ b/packages/core/src/tokenize.ts
@@ -1,7 +1,16 @@
 import { buildMatcher, type TcyOptions } from './options.js';
 
+/** A single chunk produced by {@link tokenize}. */
 export type Segment = { type: 'text'; value: string } | { type: 'tcy'; value: string };
 
+/**
+ * Split a string into an array of {@link Segment}s.
+ *
+ * Characters matching the target pattern become `tcy` segments; everything else
+ * becomes `text` segments. When {@link TcyOptions.maxLength} or
+ * {@link TcyOptions.excludeWords} is set, qualifying tcy segments are demoted
+ * back to text and adjacent text segments are merged.
+ */
 export function tokenize(input: string, options: TcyOptions = {}): Segment[] {
   if (!input) return [];
 
@@ -37,5 +46,31 @@ export function tokenize(input: string, options: TcyOptions = {}): Segment[] {
   }
   flush();
 
-  return segments;
+  return applySegmentFilter(segments, options);
+}
+
+function applySegmentFilter(segments: Segment[], options: TcyOptions): Segment[] {
+  const { maxLength, excludeWords } = options;
+  if (maxLength == null && (!excludeWords || excludeWords.length === 0)) return segments;
+
+  const excludeSet = excludeWords && excludeWords.length > 0 ? new Set(excludeWords) : null;
+
+  const shouldDemote = (seg: Segment): boolean => {
+    if (seg.type !== 'tcy') return false;
+    if (maxLength != null && seg.value.length > maxLength) return true;
+    if (excludeSet && excludeSet.has(seg.value)) return true;
+    return false;
+  };
+
+  const result: Segment[] = [];
+  for (const seg of segments) {
+    const demoted: Segment = shouldDemote(seg) ? { type: 'text', value: seg.value } : seg;
+    const last = result[result.length - 1];
+    if (last && last.type === 'text' && demoted.type === 'text') {
+      last.value += demoted.value;
+    } else {
+      result.push(demoted);
+    }
+  }
+  return result;
 }

--- a/packages/core/tests/tokenize.test.ts
+++ b/packages/core/tests/tokenize.test.ts
@@ -108,9 +108,7 @@ describe('tokenize', () => {
     });
 
     it('has no effect when all segments are within maxLength', () => {
-      expect(tokenize('A1B2', { maxLength: 10 })).toEqual([
-        { type: 'tcy', value: 'A1B2' },
-      ]);
+      expect(tokenize('A1B2', { maxLength: 10 })).toEqual([{ type: 'tcy', value: 'A1B2' }]);
     });
   });
 
@@ -126,9 +124,7 @@ describe('tokenize', () => {
     });
 
     it('does not demote partial matches', () => {
-      expect(tokenize('ABC', { excludeWords: ['AB'] })).toEqual([
-        { type: 'tcy', value: 'ABC' },
-      ]);
+      expect(tokenize('ABC', { excludeWords: ['AB'] })).toEqual([{ type: 'tcy', value: 'ABC' }]);
     });
 
     it('demotes multiple excluded words', () => {

--- a/packages/core/tests/tokenize.test.ts
+++ b/packages/core/tests/tokenize.test.ts
@@ -88,4 +88,78 @@ describe('tokenize', () => {
       { type: 'tcy', value: 'B' },
     ]);
   });
+
+  describe('maxLength', () => {
+    it('demotes tcy segments exceeding maxLength to text', () => {
+      expect(tokenize('第1章 2026年4月', { maxLength: 2 })).toEqual([
+        { type: 'text', value: '第' },
+        { type: 'tcy', value: '1' },
+        { type: 'text', value: '章 2026年' },
+        { type: 'tcy', value: '4' },
+        { type: 'text', value: '月' },
+      ]);
+    });
+
+    it('keeps tcy segments exactly at maxLength', () => {
+      expect(tokenize('AB-ABC', { maxLength: 2 })).toEqual([
+        { type: 'tcy', value: 'AB' },
+        { type: 'text', value: '-ABC' },
+      ]);
+    });
+
+    it('has no effect when all segments are within maxLength', () => {
+      expect(tokenize('A1B2', { maxLength: 10 })).toEqual([
+        { type: 'tcy', value: 'A1B2' },
+      ]);
+    });
+  });
+
+  describe('excludeWords', () => {
+    it('demotes exact-matching tcy segments to text', () => {
+      expect(tokenize('第1章 2026年4月', { excludeWords: ['2026'] })).toEqual([
+        { type: 'text', value: '第' },
+        { type: 'tcy', value: '1' },
+        { type: 'text', value: '章 2026年' },
+        { type: 'tcy', value: '4' },
+        { type: 'text', value: '月' },
+      ]);
+    });
+
+    it('does not demote partial matches', () => {
+      expect(tokenize('ABC', { excludeWords: ['AB'] })).toEqual([
+        { type: 'tcy', value: 'ABC' },
+      ]);
+    });
+
+    it('demotes multiple excluded words', () => {
+      expect(tokenize('AB-CD-EF', { excludeWords: ['AB', 'EF'] })).toEqual([
+        { type: 'text', value: 'AB-' },
+        { type: 'tcy', value: 'CD' },
+        { type: 'text', value: '-EF' },
+      ]);
+    });
+  });
+
+  describe('maxLength + excludeWords combined', () => {
+    it('demotes by either condition (OR)', () => {
+      expect(tokenize('第1章 2026年AB月', { maxLength: 2, excludeWords: ['AB'] })).toEqual([
+        { type: 'text', value: '第' },
+        { type: 'tcy', value: '1' },
+        { type: 'text', value: '章 2026年AB月' },
+      ]);
+    });
+
+    it('works with character-level exclude option', () => {
+      expect(tokenize('A1B2C', { exclude: 'B', maxLength: 1 })).toEqual([
+        { type: 'text', value: 'A1B2C' },
+      ]);
+    });
+
+    it('character-level exclude splits segments before maxLength applies', () => {
+      expect(tokenize('A-BC', { exclude: '-', maxLength: 1 })).toEqual([
+        { type: 'tcy', value: 'A' },
+        { type: 'text', value: '-BC' },
+      ]);
+    });
+  });
 });

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -45,16 +45,16 @@ Rendered DOM:
 
 ## Props
 
-| Prop        | Type                                                        | Default          | Description                                                                                  |
-| ----------- | ----------------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------- |
-| `target`    | `'alphanumeric' \| 'alpha' \| 'digit' \| 'ascii' \| RegExp` | `'alphanumeric'` | What to wrap                                                                                 |
-| `combine`   | `boolean`                                                   | `true`           | Merge consecutive target characters into one span. `false` wraps each character individually |
-| `include`   | `string \| string[]`                                        | `undefined`      | Extra characters to treat as targets                                                         |
-| `exclude`   | `string \| string[]`                                        | `undefined`      | Characters to exclude. Takes precedence over `include`                                       |
+| Prop           | Type                                                        | Default          | Description                                                                                  |
+| -------------- | ----------------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------- |
+| `target`       | `'alphanumeric' \| 'alpha' \| 'digit' \| 'ascii' \| RegExp` | `'alphanumeric'` | What to wrap                                                                                 |
+| `combine`      | `boolean`                                                   | `true`           | Merge consecutive target characters into one span. `false` wraps each character individually |
+| `include`      | `string \| string[]`                                        | `undefined`      | Extra characters to treat as targets                                                         |
+| `exclude`      | `string \| string[]`                                        | `undefined`      | Characters to exclude. Takes precedence over `include`                                       |
 | `maxLength`    | `number`                                                    | `undefined`      | Maximum length for a tcy segment. Segments longer than this are left as plain text           |
 | `excludeWords` | `string[]`                                                  | `undefined`      | Exact words to exclude from tcy wrapping                                                     |
-| `className` | `string`                                                    | `'tcy'`          | Class applied to each generated span                                                         |
-| `as`        | `keyof JSX.IntrinsicElements`                               | `'span'`         | Tag name used for wrapping                                                                   |
+| `className`    | `string`                                                    | `'tcy'`          | Class applied to each generated span                                                         |
+| `as`           | `keyof JSX.IntrinsicElements`                               | `'span'`         | Tag name used for wrapping                                                                   |
 
 Nested elements are traversed transparently. Runs are not joined across element boundaries.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -51,6 +51,8 @@ Rendered DOM:
 | `combine`   | `boolean`                                                   | `true`           | Merge consecutive target characters into one span. `false` wraps each character individually |
 | `include`   | `string \| string[]`                                        | `undefined`      | Extra characters to treat as targets                                                         |
 | `exclude`   | `string \| string[]`                                        | `undefined`      | Characters to exclude. Takes precedence over `include`                                       |
+| `maxLength`    | `number`                                                    | `undefined`      | Maximum length for a tcy segment. Segments longer than this are left as plain text           |
+| `excludeWords` | `string[]`                                                  | `undefined`      | Exact words to exclude from tcy wrapping                                                     |
 | `className` | `string`                                                    | `'tcy'`          | Class applied to each generated span                                                         |
 | `as`        | `keyof JSX.IntrinsicElements`                               | `'span'`         | Tag name used for wrapping                                                                   |
 

--- a/packages/react/src/Tcy.tsx
+++ b/packages/react/src/Tcy.tsx
@@ -9,9 +9,12 @@ import {
 } from 'react';
 import { tokenize, type TcyOptions } from '@love-rox/tcy-core';
 
+/** Props for the {@link Tcy} React component. Extends {@link TcyOptions} with rendering options. */
 export interface TcyProps extends TcyOptions {
   children: ReactNode;
+  /** Class applied to each generated wrapping element. @defaultValue `'tcy'` */
   className?: string;
+  /** HTML tag used for wrapping. @defaultValue `'span'` */
   as?: keyof JSX.IntrinsicElements;
 }
 
@@ -67,6 +70,10 @@ function transformNode(node: ReactNode, keyPrefix: string, opts: TransformOption
   return node;
 }
 
+/**
+ * React component that automatically wraps tcy-target characters in child text
+ * nodes with `<span>` (or a custom tag) for vertical typesetting.
+ */
 export function Tcy({
   children,
   className = 'tcy',

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -45,16 +45,16 @@ Rendered DOM:
 
 ## Props
 
-| Prop        | Type                                                        | Default          | Description                                                                                  |
-| ----------- | ----------------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------- |
-| `target`    | `'alphanumeric' \| 'alpha' \| 'digit' \| 'ascii' \| RegExp` | `'alphanumeric'` | What to wrap                                                                                 |
-| `combine`   | `boolean`                                                   | `true`           | Merge consecutive target characters into one span. `false` wraps each character individually |
-| `include`   | `string \| string[]`                                        | `undefined`      | Extra characters to treat as targets                                                         |
-| `exclude`   | `string \| string[]`                                        | `undefined`      | Characters to exclude. Takes precedence over `include`                                       |
+| Prop           | Type                                                        | Default          | Description                                                                                  |
+| -------------- | ----------------------------------------------------------- | ---------------- | -------------------------------------------------------------------------------------------- |
+| `target`       | `'alphanumeric' \| 'alpha' \| 'digit' \| 'ascii' \| RegExp` | `'alphanumeric'` | What to wrap                                                                                 |
+| `combine`      | `boolean`                                                   | `true`           | Merge consecutive target characters into one span. `false` wraps each character individually |
+| `include`      | `string \| string[]`                                        | `undefined`      | Extra characters to treat as targets                                                         |
+| `exclude`      | `string \| string[]`                                        | `undefined`      | Characters to exclude. Takes precedence over `include`                                       |
 | `maxLength`    | `number`                                                    | `undefined`      | Maximum length for a tcy segment. Segments longer than this are left as plain text           |
 | `excludeWords` | `string[]`                                                  | `undefined`      | Exact words to exclude from tcy wrapping                                                     |
-| `className` | `string`                                                    | `'tcy'`          | Class applied to each generated span                                                         |
-| `as`        | `string`                                                    | `'span'`         | Tag name used for wrapping                                                                   |
+| `className`    | `string`                                                    | `'tcy'`          | Class applied to each generated span                                                         |
+| `as`           | `string`                                                    | `'span'`         | Tag name used for wrapping                                                                   |
 
 Nested elements are traversed transparently. Runs are not joined across element boundaries.
 

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -51,6 +51,8 @@ Rendered DOM:
 | `combine`   | `boolean`                                                   | `true`           | Merge consecutive target characters into one span. `false` wraps each character individually |
 | `include`   | `string \| string[]`                                        | `undefined`      | Extra characters to treat as targets                                                         |
 | `exclude`   | `string \| string[]`                                        | `undefined`      | Characters to exclude. Takes precedence over `include`                                       |
+| `maxLength`    | `number`                                                    | `undefined`      | Maximum length for a tcy segment. Segments longer than this are left as plain text           |
+| `excludeWords` | `string[]`                                                  | `undefined`      | Exact words to exclude from tcy wrapping                                                     |
 | `className` | `string`                                                    | `'tcy'`          | Class applied to each generated span                                                         |
 | `as`        | `string`                                                    | `'span'`         | Tag name used for wrapping                                                                   |
 

--- a/packages/vue/src/Tcy.ts
+++ b/packages/vue/src/Tcy.ts
@@ -48,6 +48,10 @@ function transformChildren(children: unknown, ctx: TransformContext): VNodeArray
   return [];
 }
 
+/**
+ * Vue 3 component that automatically wraps tcy-target characters in child text
+ * nodes with `<span>` (or a custom tag) for vertical typesetting.
+ */
 export const Tcy = defineComponent({
   name: 'Tcy',
   props: {

--- a/packages/vue/src/Tcy.ts
+++ b/packages/vue/src/Tcy.ts
@@ -66,6 +66,14 @@ export const Tcy = defineComponent({
       type: [String, Array] as PropType<string | string[]>,
       default: undefined,
     },
+    maxLength: {
+      type: Number as PropType<number>,
+      default: undefined,
+    },
+    excludeWords: {
+      type: Array as PropType<string[]>,
+      default: undefined,
+    },
   },
   setup(props, { slots }) {
     return () => {
@@ -77,6 +85,8 @@ export const Tcy = defineComponent({
           combine: props.combine,
           include: props.include,
           exclude: props.exclude,
+          maxLength: props.maxLength,
+          excludeWords: props.excludeWords,
         },
       };
       const children = slots.default?.() ?? [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       oxlint:
         specifier: ^1.60.0
         version: 1.60.0
+      typedoc:
+        specifier: ^0.28.19
+        version: 0.28.19(typescript@5.9.3)
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -317,6 +320,9 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
+
+  '@gerrit0/mini-shiki@3.23.0':
+    resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
   '@inquirer/external-editor@1.0.3':
     resolution: {integrity: sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA==}
@@ -741,6 +747,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -766,6 +787,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -779,6 +803,9 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -896,12 +923,20 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1015,6 +1050,10 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -1241,6 +1280,9 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -1258,6 +1300,9 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lunr@2.3.9:
+    resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -1265,9 +1310,16 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1284,6 +1336,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
 
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
@@ -1409,6 +1465,10 @@ packages:
 
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -1576,10 +1636,20 @@ packages:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
 
+  typedoc@0.28.19:
+    resolution: {integrity: sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==}
+    engines: {node: '>= 18', pnpm: '>= 10'}
+    hasBin: true
+    peerDependencies:
+      typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -1714,6 +1784,11 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
 snapshots:
 
@@ -1978,6 +2053,14 @@ snapshots:
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
+  '@gerrit0/mini-shiki@3.23.0':
+    dependencies:
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
   '@inquirer/external-editor@1.0.3':
     dependencies:
       chardet: 2.1.1
@@ -2216,6 +2299,26 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
 
+  '@shikijs/engine-oniguruma@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/themes@3.23.0':
+    dependencies:
+      '@shikijs/types': 3.23.0
+
+  '@shikijs/types@3.23.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -2241,6 +2344,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/node@12.20.55': {}
 
   '@types/prop-types@15.7.15': {}
@@ -2253,6 +2360,8 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@types/unist@3.0.3': {}
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -2389,6 +2498,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
@@ -2396,6 +2507,10 @@ snapshots:
   brace-expansion@2.1.0:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -2498,6 +2613,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -2774,6 +2891,10 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -2788,13 +2909,26 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lunr@2.3.9: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   math-intrinsics@1.1.0: {}
+
+  mdurl@2.0.0: {}
 
   merge2@1.4.1: {}
 
@@ -2808,6 +2942,10 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
 
   minimatch@9.0.9:
     dependencies:
@@ -2937,6 +3075,8 @@ snapshots:
       react-is: 17.0.2
 
   proto-list@1.2.4: {}
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -3099,7 +3239,18 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  typedoc@0.28.19(typescript@5.9.3):
+    dependencies:
+      '@gerrit0/mini-shiki': 3.23.0
+      lunr: 2.3.9
+      markdown-it: 14.1.1
+      minimatch: 10.2.5
+      typescript: 5.9.3
+      yaml: 2.8.3
+
   typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
 
   universalify@0.1.2: {}
 
@@ -3219,3 +3370,5 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  yaml@2.8.3: {}

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "include": [
+    "packages/core/src",
+    "packages/react/src",
+    "packages/vue/src"
+  ]
+}

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -3,9 +3,5 @@
   "compilerOptions": {
     "jsx": "react-jsx"
   },
-  "include": [
-    "packages/core/src",
-    "packages/react/src",
-    "packages/vue/src"
-  ]
+  "include": ["packages/core/src", "packages/react/src", "packages/vue/src"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": [
+    "packages/core/src/index.ts",
+    "packages/react/src/index.ts",
+    "packages/vue/src/index.ts"
+  ],
+  "tsconfig": "tsconfig.typedoc.json",
+  "emit": "none",
+  "validation": {
+    "notDocumented": true,
+    "invalidLink": false
+  },
+  "treatWarningsAsErrors": true
+}


### PR DESCRIPTION
## Summary

- `maxLength` オプション: tcy セグメントの最大文字数を制限し、超過分をプレーンテキストに戻す (#9)
- `excludeWords` オプション: 特定の単語を完全一致で tcy 対象から除外する (#10)
- 両オプションはグループ化後のポストフィルタとして統一的に実装し、隣接する text セグメントを自動マージ
- TSDoc、README (EN/JA)、パッケージ別 README、テスト (9件追加) を更新

Closes #9
Closes #10

## Test plan

- [x] `pnpm test` — 全21テストがパス (新規9件含む)
- [x] `pnpm build` — 全パッケージのビルド成功
- [ ] CI パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)