### PR TITLE
docs(rehype): root README mentions, demo example, and 0.2.1 changeset

### DIFF
--- a/.changeset/rehype-provenance-and-docs.md
+++ b/.changeset/rehype-provenance-and-docs.md
@@ -1,0 +1,8 @@
+---
+'@love-rox/tcy-rehype': patch
+---
+
+Re-publish via the standard changesets/OIDC release flow so the package
+ships with provenance attestations (the initial 0.2.0 was published via
+a one-off bootstrap and lacks attestations). No source changes; ships an
+example `examples/demo.mjs` alongside the package.

--- a/README.ja.md
+++ b/README.ja.md
@@ -7,6 +7,7 @@
 - **`@love-rox/tcy-core`** — フレームワーク非依存のトークナイザ
 - **`@love-rox/tcy-react`** — React 用 `<Tcy>` コンポーネント
 - **`@love-rox/tcy-vue`** — Vue 3 用 `<Tcy>` コンポーネント
+- **`@love-rox/tcy-rehype`** — `unified` の HAST パイプライン用 rehype プラグイン
 
 ## なぜ必要か
 
@@ -20,6 +21,9 @@ pnpm add @love-rox/tcy-react
 
 # Vue
 pnpm add @love-rox/tcy-vue
+
+# rehype（Markdown / HAST パイプライン用）
+pnpm add @love-rox/tcy-rehype
 
 # コアのみ（独自ラッパーを書く場合）
 pnpm add @love-rox/tcy-core
@@ -72,6 +76,26 @@ import { Tcy } from '@love-rox/tcy-vue';
 </template>
 ```
 
+### rehype（unified パイプライン）
+
+```ts
+import { unified } from 'unified';
+import rehypeParse from 'rehype-parse';
+import rehypeStringify from 'rehype-stringify';
+import rehypeTcy from '@love-rox/tcy-rehype';
+
+const html = String(
+  await unified()
+    .use(rehypeParse, { fragment: true })
+    .use(rehypeTcy)
+    .use(rehypeStringify)
+    .process('<p>第1章 2026年4月</p>'),
+);
+// <p>第<span class="tcy">1</span>章 <span class="tcy">2026</span>年<span class="tcy">4</span>月</p>
+```
+
+`<code>` / `<pre>` / `<script>` / `<style>` の中は既定で対象外（`skipTags` で変更可）。プラグイン固有のオプションは `tagName` / `className` / `skipTags` のみで、その他は[オプション](#オプション)と共通です。
+
 ### Core（文字列トークナイズ）
 
 ```ts
@@ -108,6 +132,14 @@ React / Vue コンポーネント固有:
 | ----------- | -------- | -------- | ------------------------------------------------------------ |
 | `className` | `string` | `'tcy'`  | 生成する span に付くクラス名                                 |
 | `as`        | `string` | `'span'` | ラップ要素のタグ名（React は `keyof JSX.IntrinsicElements`） |
+
+rehype プラグイン固有:
+
+| オプション  | 型                   | 既定値                               | 内容                                           |
+| ----------- | -------------------- | ------------------------------------ | ---------------------------------------------- |
+| `tagName`   | `string`             | `'span'`                             | ラップ要素のタグ名                             |
+| `className` | `string \| string[]` | `'tcy'`                              | 生成する要素に付くクラス名                     |
+| `skipTags`  | `string[]`           | `['code', 'pre', 'script', 'style']` | サブツリーを処理せずそのまま残すタグ名のリスト |
 
 ## 例
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Automatic **tate-chu-yoko (縦中横)** wrapping for Japanese vertical writing. 
 - **`@love-rox/tcy-core`** — framework-agnostic tokenizer
 - **`@love-rox/tcy-react`** — React `<Tcy>` component
 - **`@love-rox/tcy-vue`** — Vue 3 `<Tcy>` component
+- **`@love-rox/tcy-rehype`** — rehype plugin for `unified` HAST pipelines
 
 ## Why
 
@@ -20,6 +21,9 @@ pnpm add @love-rox/tcy-react
 
 # Vue
 pnpm add @love-rox/tcy-vue
+
+# rehype (Markdown / HAST pipelines)
+pnpm add @love-rox/tcy-rehype
 
 # Core only (for writing your own wrapper)
 pnpm add @love-rox/tcy-core
@@ -72,6 +76,26 @@ import { Tcy } from '@love-rox/tcy-vue';
 </template>
 ```
 
+### rehype (unified pipeline)
+
+```ts
+import { unified } from 'unified';
+import rehypeParse from 'rehype-parse';
+import rehypeStringify from 'rehype-stringify';
+import rehypeTcy from '@love-rox/tcy-rehype';
+
+const html = String(
+  await unified()
+    .use(rehypeParse, { fragment: true })
+    .use(rehypeTcy)
+    .use(rehypeStringify)
+    .process('<p>第1章 2026年4月</p>'),
+);
+// <p>第<span class="tcy">1</span>章 <span class="tcy">2026</span>年<span class="tcy">4</span>月</p>
+```
+
+Text inside `<code>`, `<pre>`, `<script>`, and `<style>` is skipped by default (configurable via `skipTags`). Plugin-only options are `tagName`, `className`, and `skipTags`; the rest of the [Options](#options) below apply identically.
+
 ### Core (string tokenizer)
 
 ```ts
@@ -108,6 +132,14 @@ Component-only props (React / Vue):
 | ----------- | -------- | -------- | ----------------------------------------------------------------- |
 | `className` | `string` | `'tcy'`  | Class applied to each generated span                              |
 | `as`        | `string` | `'span'` | Tag name used for wrapping (React: `keyof JSX.IntrinsicElements`) |
+
+Plugin-only options (rehype):
+
+| Option      | Type                 | Default                              | Description                                     |
+| ----------- | -------------------- | ------------------------------------ | ----------------------------------------------- |
+| `tagName`   | `string`             | `'span'`                             | Tag name used for wrapping                      |
+| `className` | `string \| string[]` | `'tcy'`                              | Class name(s) applied to each generated element |
+| `skipTags`  | `string[]`           | `['code', 'pre', 'script', 'style']` | Tag names whose subtrees are left untouched     |
 
 ## Examples
 

--- a/packages/rehype/examples/demo.mjs
+++ b/packages/rehype/examples/demo.mjs
@@ -1,0 +1,32 @@
+/**
+ * Run from packages/rehype after `pnpm --filter @love-rox/tcy-rehype build`:
+ *
+ *   node examples/demo.mjs
+ */
+import { unified } from 'unified';
+import rehypeParse from 'rehype-parse';
+import rehypeStringify from 'rehype-stringify';
+import rehypeTcy from '../dist/rehype-tcy.js';
+
+const samples = [
+  ['default', '<p>第1章 2026年4月、Webの縦書きは進化した。</p>'],
+  ['skips <code>', '<p>第1章</p><pre><code>const x = 123;</code></pre>'],
+  ['nested elements', '<p>前<strong>ABC123</strong>後</p>'],
+];
+
+const make = (options) =>
+  unified().use(rehypeParse, { fragment: true }).use(rehypeTcy, options).use(rehypeStringify);
+
+console.log('--- default ---');
+for (const [label, html] of samples) {
+  const out = String(await make().process(html));
+  console.log(`[${label}]\n  in : ${html}\n  out: ${out}\n`);
+}
+
+console.log('--- excludeWords: ["2026"] ---');
+console.log(String(await make({ excludeWords: ['2026'] }).process('<p>第1章 2026年4月</p>')));
+
+console.log('\n--- custom tagName / className ---');
+console.log(
+  String(await make({ tagName: 'b', className: ['tcy', 'mark'] }).process('<p>AB12</p>')),
+);


### PR DESCRIPTION
## Summary
- Mention `@love-rox/tcy-rehype` in `README.md` / `README.ja.md` (package list + Install + a unified pipeline usage section + plugin-only options table)
- Add `packages/rehype/examples/demo.mjs` — runnable with `node examples/demo.mjs` after `pnpm --filter @love-rox/tcy-rehype build`
- Add a patch changeset so the next release goes through the standard changesets/OIDC flow and ships with provenance attestations (initial 0.2.0 was a one-off bootstrap publish and lacks attestations)

## Test plan
- [x] `pnpm test` — 42 tests pass
- [x] `pnpm typecheck` — pass
- [x] `pnpm build` — pass
- [x] `pnpm lint` — pass
- [x] `pnpm format:check` — pass
- [x] `pnpm check:tsdoc` — pass
- [x] `node packages/rehype/examples/demo.mjs` — actual output matches inline expectations

## Release expectation
After merge, `release.yml` (changesets/action) opens a Release PR that bumps `@love-rox/tcy-rehype` to `0.2.1`. Merging that Release PR triggers the OIDC publish (with provenance + GitHub Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)