### PR TITLE
chore: lock all packages to a single fixed version line

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,9 @@
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
   "changelog": "@changesets/cli/changelog",
   "commit": false,
-  "fixed": [],
+  "fixed": [
+    ["@love-rox/tcy-core", "@love-rox/tcy-react", "@love-rox/tcy-vue", "@love-rox/tcy-rehype"]
+  ],
   "linked": [],
   "access": "public",
   "baseBranch": "main",

--- a/.changeset/sync-versions-to-0.2.2.md
+++ b/.changeset/sync-versions-to-0.2.2.md
@@ -1,0 +1,11 @@
+---
+'@love-rox/tcy-core': patch
+'@love-rox/tcy-react': patch
+'@love-rox/tcy-vue': patch
+'@love-rox/tcy-rehype': patch
+---
+
+Sync all packages to the same version. Going forward, the four
+publishable packages (`@love-rox/tcy-core`, `@love-rox/tcy-react`,
+`@love-rox/tcy-vue`, `@love-rox/tcy-rehype`) are kept on a single fixed
+version line via changesets `fixed` configuration.


### PR DESCRIPTION
## Summary
- Add a `fixed` group in `.changeset/config.json` covering `@love-rox/tcy-core`, `@love-rox/tcy-react`, `@love-rox/tcy-vue`, and `@love-rox/tcy-rehype` so the four publishable packages always release together on a single version line
- Include a patch changeset that bumps everything to **0.2.2** (rehype is currently `0.2.1`, the others are `0.2.0` — the next release puts them all on `0.2.2`)

## Why
After the rehype package was added, only `@love-rox/tcy-rehype` got bumped to `0.2.1`, leaving versions out of sync. Since this monorepo is a single feature (tate-chu-yoko) split into four delivery surfaces (core/react/vue/rehype), keeping a single fixed version line is simpler than independent versioning.

## Verified
- [x] `pnpm exec changeset status --verbose` reports all 4 packages bumping to `0.2.2`
- [x] `pnpm test` / `typecheck` / `build` / `lint` / `format:check` / `check:tsdoc` all pass

## Release expectation
After merge, `release.yml` opens a Release PR that bumps all 4 packages to `0.2.2`. Merging that PR triggers OIDC publish (with provenance) for all 4 packages plus their GitHub Releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)