### PR TITLE
ci: switch release workflow to GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,19 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
+      # Mint a token from a GitHub App installation so the Release PR pushed by
+      # changesets/action is authored by the App (not GITHUB_TOKEN), letting the
+      # resulting push trigger required CI checks. App tokens auto-rotate hourly,
+      # so there is no PAT expiry to manage.
+      - id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: pnpm/action-setup@v5
 
@@ -35,5 +47,5 @@ jobs:
           commit: 'chore(release): version packages'
           title: 'chore(release): version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NPM_CONFIG_PROVENANCE: 'true'


### PR DESCRIPTION
## Summary
- Mint an installation token from a GitHub App via \`actions/create-github-app-token\` and pass it to \`changesets/action\`
- Use the same token for the initial \`actions/checkout\` so subsequent pushes are authored by the App
- App tokens auto-rotate hourly — no PAT expiry to babysit

## Why
\`secrets.GITHUB_TOKEN\` cannot trigger other workflow runs (GitHub's loop-prevention). With the default token, every Release PR created by changesets/action sits with no CI runs, so required status checks never pass and the PR cannot be merged. Switching to an App token avoids the entire problem.

## Required setup before merging
The workflow now references two repository secrets that must exist or the workflow will fail. Setup steps (one-time):

1. Create a GitHub App at https://github.com/organizations/Love-Rox/settings/apps/new
   - Name: e.g. \`love-rox-release-bot\`
   - **Webhook → Active: off**
   - Repository permissions: **Contents: R/W**, **Pull requests: R/W**, **Workflows: R/W**, Metadata: R
   - Installable: Only on this account
2. Generate a private key (\`.pem\` will download)
3. Install the App on \`Love-Rox/tate-chu-yoko\` only
4. Register secrets:
   \`\`\`bash
   gh secret set RELEASE_APP_ID -R Love-Rox/tate-chu-yoko --body '<APP_ID>'
   gh secret set RELEASE_APP_PRIVATE_KEY -R Love-Rox/tate-chu-yoko < /path/to/key.pem
   \`\`\`

## Test plan
- [ ] Merge this PR
- [ ] Add a no-op changeset (e.g. \`pnpm changeset\` then commit)
- [ ] Push to main and confirm the Release PR's CI starts automatically without an empty-commit nudge

🤖 Generated with [Claude Code](https://claude.com/claude-code)