### PR TITLE
ci: bump actions/create-github-app-token to v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       # resulting push trigger required CI checks. App tokens auto-rotate hourly,
       # so there is no PAT expiry to manage.
       - id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Bump \`actions/create-github-app-token\` from \`@v1\` to \`@v3\` (latest: v3.1.1)
- Resolves the GitHub Actions deprecation annotation: "Node.js 20 actions are deprecated... Node.js 20 will be removed from the runner on 2026-09-16"

## Notes
- \`@v3\` ships on Node.js 24 — clears the warning
- v3 deprecates the \`app-id\` input in favor of \`client-id\`, but \`app-id\` still works (deprecationMessage only). Keeping the existing \`RELEASE_APP_ID\` secret name to avoid an unnecessary rotation. We can switch to \`client-id\` in a follow-up if desired

## Test plan
- [ ] Merge this PR
- [ ] Confirm the next Release workflow run no longer raises the Node.js 20 deprecation annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)