### PR TITLE
ci: switch create-github-app-token input to client-id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Switch \`actions/create-github-app-token@v3\` input from \`app-id\` to \`client-id\` (uses the new \`RELEASE_APP_CLIENT_ID\` secret)
- Clears the two remaining deprecation annotations: "Input 'app-id' has been deprecated with message: Use 'client-id' instead."

## Notes
- \`RELEASE_APP_PRIVATE_KEY\` is reused unchanged
- \`RELEASE_APP_ID\` secret is no longer referenced; it can be deleted after merge with:
  \`\`\`bash
  gh secret delete RELEASE_APP_ID -R Love-Rox/tate-chu-yoko
  \`\`\`

## Test plan
- [ ] Merge this PR
- [ ] Confirm the next Release run reports zero annotations on the release check

🤖 Generated with [Claude Code](https://claude.com/claude-code)