### PR TITLE
fix(astro): republish tcy-astro to resolve workspace:* in published deps

### DIFF
--- a/.changeset/republish-tcy-astro.md
+++ b/.changeset/republish-tcy-astro.md
@@ -1,9 +1,9 @@
 ---
-"@love-rox/tcy-astro": patch
-"@love-rox/tcy-core": patch
-"@love-rox/tcy-react": patch
-"@love-rox/tcy-rehype": patch
-"@love-rox/tcy-vue": patch
+'@love-rox/tcy-astro': patch
+'@love-rox/tcy-core': patch
+'@love-rox/tcy-react': patch
+'@love-rox/tcy-rehype': patch
+'@love-rox/tcy-vue': patch
 ---
 
 Republish to fix broken `workspace:*` dependency specifiers in `@love-rox/tcy-astro@0.3.0`.

--- a/.changeset/republish-tcy-astro.md
+++ b/.changeset/republish-tcy-astro.md
@@ -1,0 +1,15 @@
+---
+"@love-rox/tcy-astro": patch
+"@love-rox/tcy-core": patch
+"@love-rox/tcy-react": patch
+"@love-rox/tcy-rehype": patch
+"@love-rox/tcy-vue": patch
+---
+
+Republish to fix broken `workspace:*` dependency specifiers in `@love-rox/tcy-astro@0.3.0`.
+
+The 0.3.0 release of `@love-rox/tcy-astro` was published manually via `npm publish` after the OIDC trusted-publishing flow returned 404 for the brand-new package on npmjs.com. Because `npm publish` (unlike `pnpm publish`) does not rewrite pnpm's `workspace:*` protocol, the published manifest left dependency specifiers as `workspace:*`, causing `npm install @love-rox/tcy-astro` to fail with `EUNSUPPORTEDPROTOCOL`.
+
+This release republishes the affected package family through the standard `pnpm publish` flow (changesets/action), restoring proper version-pinned dependencies.
+
+Refs: #25


### PR DESCRIPTION
## Summary

- `@love-rox/tcy-astro@0.3.0` を `workspace:*` 入りの破損状態で再公開しないよう、changeset を追加して fixed-version グループ全体をパッチバンプします (#25 の対応)。
- 次回マージされる Release PR で `pnpm publish` 経由の再公開が走り、依存指定が正しいバージョン番号に置換されます。

## Background

- 公開済みの 0.3.0 は `dependencies` に `"@love-rox/tcy-core": "workspace:*"` 等が残っており、`npm install @love-rox/tcy-astro` が `EUNSUPPORTEDPROTOCOL` で失敗します ([#25](https://github.com/Love-Rox/tate-chu-yoko/issues/25))。
- 元のリリース実行 ([run 25266577608](https://github.com/Love-Rox/tate-chu-yoko/actions/runs/25266577608)) では、新規パッケージの `@love-rox/tcy-astro` に対して OIDC trusted publishing が `E404` を返して失敗していました。その後、手動で `npm publish` した結果、pnpm の `workspace:*` プロトコルが置換されないまま公開されてしまったのが原因です。

## Action items (要・人手対応)

このPRをマージするだけでは npm 上の状態は完全には直りません。以下を別途実施してください:

1. **npmjs.com 側で `@love-rox/tcy-astro` の Trusted Publisher を設定**
   `core` / `react` / `rehype` / `vue` は OIDC で公開できているので、同じ trusted publisher 設定を `tcy-astro` にも追加します。これがないと、Release PR をマージしても再び 404 になります。
2. **このPRをマージ**
   → changesets/action が Release PR を起票します。
3. **Release PR をマージ** → 0.3.1 が `pnpm publish` 経由で全パッケージ公開されます。
4. **破損した 0.3.0 を deprecate** (任意・推奨)
   ```sh
   npm deprecate @love-rox/tcy-astro@0.3.0 "broken: workspace:* in published deps; use 0.3.1 or later"
   ```

## Test plan

- [ ] このPRをマージすると Release PR が自動で起票される
- [ ] Release PR マージ後、`npm view @love-rox/tcy-astro@0.3.1 dependencies` で `workspace:*` が消えていること
- [ ] `npm install @love-rox/tcy-astro` がエラーなく完了すること
- [ ] 0.3.0 を deprecate 済み

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)